### PR TITLE
Add setting for alphabetical sorting of completions

### DIFF
--- a/OdinCompletions.py
+++ b/OdinCompletions.py
@@ -250,10 +250,16 @@ class OdinCompletions(sublime_plugin.EventListener):
       package_or_filename = self.search_package or os.path.split(path)[1]
       completions += parser.get_completions_from_file(package_or_filename, self.get_file_contents(path))
 
+    #sort completions alphabetically
+    if view.settings().get('odin_sort_completions_alphabetical', True):
+      completions.sort()
+
     # Report time spent building completions before returning
     delta_time_ms = int((time.time() - start_time) * 1000)
     message = 'Odin autocompletion took ' + str(delta_time_ms) + 'ms. Completions: ' + str(len(completions)) + '. Paths: ' + str(len(paths))
     view.window().status_message(message)
+
+
 
     return completions
 

--- a/odin_set_vc_vars.py
+++ b/odin_set_vc_vars.py
@@ -15,7 +15,7 @@ def _get_vc_env():
 	Returns None if the batch file fails.
 	"""
 	settings = sublime.load_settings('Preferences.sublime-settings')
-	vars_cmd = settings.get('vc_vars_path', 'C:\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat')
+	vars_cmd = settings.get('odin_vc_vars_path', 'C:\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat')
 	"""vars_arch = settings.get("vc_vars_arch", "amd64")"""
 
 	try:


### PR DESCRIPTION
Not sure if the current completion order has a rhyme or reason, maybe the completions are listed in the order they come from the packages? I find it a little more helpful to have them alphabetically sorted, so I added that as a setting.

Also appended "odin_" to the "vc_vars_path" so it matches the other odin related settings.